### PR TITLE
python 2/3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 2.7
     - 3.3
     - 3.4
+    - 3.5
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -49,7 +50,7 @@ matrix:
         # Try Astropy development version
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='test'
-        - python: 3.4
+        - python: 3.5
           env: ASTROPY_VERSION=development SETUP_CMD='test'
 
         # Try older numpy versions

--- a/README.rst
+++ b/README.rst
@@ -28,4 +28,4 @@ remove a scipy dependency.
 
 Examples to come!  PRs welcome!
 
-Tested in Python 2.7 and 3.4
+Tested in Python 2.7 and 3.5

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,10 @@ from setuptools import setup
 #A dirty hack to get around some early import/configurations ambiguities
 if sys.version_info[0] >= 3:
     import builtins
+    from distutils.config import RawConfigParser as ConfigParser
 else:
     import __builtin__ as builtins
+    from distutils.config import ConfigParser
 builtins._ASTROPY_SETUP_ = True
 
 from astropy_helpers.setup_helpers import (
@@ -21,8 +23,7 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,8 @@ from setuptools import setup
 #A dirty hack to get around some early import/configurations ambiguities
 if sys.version_info[0] >= 3:
     import builtins
-    from distutils.config import RawConfigParser as ConfigParser
 else:
     import __builtin__ as builtins
-    from distutils.config import ConfigParser
 builtins._ASTROPY_SETUP_ = True
 
 from astropy_helpers.setup_helpers import (
@@ -23,6 +21,7 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
+from six.moves.configparser import ConfigParser
 conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
-from six.moves.configparser import ConfigParser
+from astropy.extern.six.moves.configparser import ConfigParser
 conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))


### PR DESCRIPTION
Trivial change to allow install in Python 2 and Python 3.
